### PR TITLE
fixed javascript strings escaping

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const { promisify } = require('util');
 const inquirer = require('inquirer');
 const program = require('commander');
 const colors = require('colors');
+const jsStringEscape = require('js-string-escape');
 
 const readFileAsync = promisify(fs.readFile);
 const readdirAsync = promisify(fs.readdir);
@@ -62,7 +63,7 @@ const initModule = ({
     const genResxObj = (content, name) => `${jsNamespace}.${name} = {${NEW_LINE}${content}${NEW_LINE}};`;
     const genResxStrs = json => {
         const keys = Object.keys(json).sort();
-        return keys.map(k => `${TAB}${k}: '${json[k]}',`);
+        return keys.map(k => `${TAB}${k}: '${jsStringEscape(json[k])}',`);
     };
     const genResxDistBody = (name, langData, defaultLangData) => {
         let distData = langData;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resxprocessor",
-  "version": "1.1.0",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -836,6 +836,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "js-string-escape": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
+      "integrity": "sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "colors": "^1.3.2",
     "commander": "^2.19.0",
-    "inquirer": "^6.2.0"
+    "inquirer": "^6.2.0",
+    "js-string-escape": "^1.0.1"
   },
   "devDependencies": {
     "eslint": "^5.8.0",


### PR DESCRIPTION
Fixed javascript strings escaping during resx files generation in dist folder.

If source resources contain some quotes, result json contains invalid strings. See example:

source resource string
`"email_nt_off_radiobtn_description": "You won't receive any email notifications including follower notifications."`
converted to 
`email_nt_off_radiobtn_description: 'You won't receive any email notifications including follower notifications.'` without any escaping.


P.S. Thank you very much for grateful and useful package. We enjoy using it in our production project!
Please update npm package if everything is OK when you have some free time. Thank you.